### PR TITLE
Feature/add pages

### DIFF
--- a/ui/model.go
+++ b/ui/model.go
@@ -10,11 +10,9 @@ type MenuItem struct {
 }
 
 const (
-	PageHome     Page = "home"
-	PageAbout    Page = "about"
-	PageProjects Page = "projects"
-	PageBlog     Page = "blog"
-	PageContact  Page = "contact"
+	PageHome    Page = "home"
+	PageAbout   Page = "about"
+	PageContact Page = "contact"
 )
 
 type Model struct {
@@ -29,8 +27,6 @@ func InitialModel() Model {
 		cursor:      0,
 		menuItems: []MenuItem{
 			{label: "About", page: PageAbout},
-			{label: "Projects", page: PageProjects},
-			{label: "Blog", page: PageBlog},
 			{label: "Contact", page: PageContact},
 		},
 	}

--- a/ui/pages/about.go
+++ b/ui/pages/about.go
@@ -2,18 +2,18 @@ package pages
 
 func AboutView() string {
 	return `
-	Edwin is a passionate software developer with over 12 years of experience, transforming 
-	his love for programming from a hobby into a thriving career. As a self-taught developer, he thrives 
-	on continuous learning and problem-solving, always looking for new ways to level up his skills. 
-	Currently, he's diving deep into backend development terminals and shells, sharpening his expertise and filling 
-	in the gaps he missed along the way.
+Edwin is a passionate software developer with over 12 years of experience, transforming 
+his love for programming from a hobby into a thriving career. As a self-taught developer, he thrives 
+on continuous learning and problem-solving, always looking for new ways to level up his skills. 
+Currently, he's diving deep into backend development terminals and shells, sharpening his expertise and filling 
+in the gaps he missed along the way.
 
 But coding isn’t just a job for Edwin—it’s a lifelong passion. When he's not crafting efficient code, 
-	he’s spending quality time with his wife and three amazing kids, 
-	indulging in the simple joys of family life. Whether it's getting lost in a gripping series, 
-	battling it out in a video game, or enjoying the strategy of a great board game, he loves unwinding 
-	with immersive experiences.
+he’s spending quality time with his wife and three amazing kids, 
+indulging in the simple joys of family life. Whether it's getting lost in a gripping series, 
+battling it out in a video game, or enjoying the strategy of a great board game, he loves unwinding 
+with immersive experiences.
 
 And let's not forget his refined taste for good coffee and specialty beers—because life is too short 
-	for anything less than top-tier brews!`
+for anything less than top-tier brews!`
 }

--- a/ui/pages/about.go
+++ b/ui/pages/about.go
@@ -1,0 +1,19 @@
+package pages
+
+func AboutView() string {
+	return `
+	Edwin is a passionate software developer with over 12 years of experience, transforming 
+	his love for programming from a hobby into a thriving career. As a self-taught developer, he thrives 
+	on continuous learning and problem-solving, always looking for new ways to level up his skills. 
+	Currently, he's diving deep into backend development terminals and shells, sharpening his expertise and filling 
+	in the gaps he missed along the way.
+
+But coding isn’t just a job for Edwin—it’s a lifelong passion. When he's not crafting efficient code, 
+	he’s spending quality time with his wife and three amazing kids, 
+	indulging in the simple joys of family life. Whether it's getting lost in a gripping series, 
+	battling it out in a video game, or enjoying the strategy of a great board game, he loves unwinding 
+	with immersive experiences.
+
+And let's not forget his refined taste for good coffee and specialty beers—because life is too short 
+	for anything less than top-tier brews!`
+}

--- a/ui/pages/contact.go
+++ b/ui/pages/contact.go
@@ -1,0 +1,10 @@
+package pages
+
+func ContactView() string {
+	return `Contact me at:
+
+- Email: hello@edwinboon.dev
+- Github: https://www.github.com/edwinboon
+
+`
+}

--- a/ui/pages/home.go
+++ b/ui/pages/home.go
@@ -1,0 +1,20 @@
+package pages
+
+import (
+	"fmt"
+)
+
+func HomeView(cursor int, menuItems []string) string {
+	s := "use the j and k keys to navigate, and enter to select a page\n\n"
+
+	for i, item := range menuItems {
+		c := " " // no cursor
+		if cursor == i {
+			c = ">" // cursor!
+		}
+
+		s += fmt.Sprintf("%s %s\n", c, item)
+	}
+
+	return s
+}

--- a/ui/update.go
+++ b/ui/update.go
@@ -7,6 +7,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q":
+			if m.currentPage != PageHome {
+				m.currentPage = PageHome
+				return m, nil
+			}
+
 			return m, tea.Quit
 		case "k", "up":
 			if m.cursor > 0 {

--- a/ui/view.go
+++ b/ui/view.go
@@ -1,21 +1,19 @@
 package ui
 
 import (
-	"fmt"
-
 	tea "charm.land/bubbletea/v2"
+	"github.com/edwinboon/tui-portfolio/ui/pages"
 )
 
 func (m Model) View() tea.View {
-	s := "use the j and k keys to navigate, and enter to select a page\n\n"
-
-	for i, item := range m.menuItems {
-		cursor := " " // no cursor
-		if m.cursor == i {
-			cursor = ">" // cursor!
-		}
-		s += fmt.Sprintf("%s %s\n", cursor, item.label)
+	if m.currentPage != PageHome {
+		return tea.NewView("Page: " + string(m.currentPage))
 	}
 
-	return tea.NewView(s)
+	labels := make([]string, len(m.menuItems))
+	for i, item := range m.menuItems {
+		labels[i] = item.label
+	}
+
+	return tea.NewView(pages.HomeView(m.cursor, labels))
 }

--- a/ui/view.go
+++ b/ui/view.go
@@ -6,8 +6,11 @@ import (
 )
 
 func (m Model) View() tea.View {
-	if m.currentPage != PageHome {
-		return tea.NewView("Page: " + string(m.currentPage))
+	switch m.currentPage {
+	case PageAbout:
+		return tea.NewView(pages.AboutView())
+	case PageContact:
+		return tea.NewView(pages.ContactView())
 	}
 
 	labels := make([]string, len(m.menuItems))


### PR DESCRIPTION
 Add page routing with Home, About and Contact views

  Introduces a ui/pages sub-package with separate view functions per page, and wires up navigation in view.go
  using a switch on currentPage.

  What's included

  - ui/pages/home.go — menu renderer, extracted from view.go
  - ui/pages/about.go — static about page with bio text
  - ui/pages/contact.go — contact page with email and GitHub links
  - ui/view.go — refactored to use a switch for page routing