### PR TITLE
 Deploy on tag instead of every push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,15 +2,15 @@ name: Deploy to VPS
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 
 concurrency:
   group: deploy
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   deploy:
@@ -26,6 +26,12 @@ jobs:
 
       - name: Build
         run: GOOS=linux GOARCH=arm64 go build -o tui-portfolio-linux .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2
+        with:
+          files: tui-portfolio-linux
+          generate_release_notes: true
 
       - name: Upload binary
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,8 @@ on:
       - 'v*'
 
 concurrency:
-  group: deploy
-  cancel-in-progress: true
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -26,12 +26,6 @@ jobs:
 
       - name: Build
         run: GOOS=linux GOARCH=arm64 go build -o tui-portfolio-linux .
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2
-        with:
-          files: tui-portfolio-linux
-          generate_release_notes: true
 
       - name: Upload binary
         uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
@@ -56,3 +50,9 @@ jobs:
             mv /root/tui-portfolio-linux.new/tui-portfolio-linux /root/tui-portfolio-linux
             rmdir /root/tui-portfolio-linux.new
             systemctl restart tui-portfolio
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2
+        with:
+          files: tui-portfolio-linux
+          generate_release_notes: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 concurrency:
-  group: deploy-${{ github.ref }}
+  group: deploy
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
Deploy on tag instead of every push to main

  Changes the deploy trigger from pushing to main to pushing a version tag (v*), giving full control over when a new version goes live.

  Changes

  - Deploy workflow now triggers on v* tags only (e.g. v1.0.0)
  - Automatically creates a GitHub Release with the compiled binary and generated release notes
  - Updated permissions to contents: write to allow release creation

  How to deploy

  git tag v1.0.0
  git push --tags